### PR TITLE
Improve the makefile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ y.*
 lex.yy.c
 *.out
 tags
+*.o


### PR DESCRIPTION
Compile every source file to an object file, then link it all together. This will make it compile only the files that have changed.

A side-effect that I'm hoping for is making it possible to compile flathead with compilers that have failed to do so due to linking errors.

This can be considered a work in progress, so feel free to reject this pull request.

The object files could be obtained with wildcards (example below), but I have a preference for explicit lists in such cases.

OBJ_FILES = $(patsubst %.c,%.o,$(wildcard ./_.c src/_.c src/runtime/_.c src/runtime/lib/_.c))
