### PR TITLE
Added vfp if no fpu was detected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@
 
 CC = gcc
 CFLAGS = -Wall -Wextra -Wno-unused-parameter -O3 -std=c99 -pedantic -D_XOPEN_SOURCE
+CFLAGS += $(shell cat /proc/cpuinfo | grep fpu | grep yes > /dev/null || { echo -n "-mfloat-abi=softfp -mfpu=" ; cat /proc/cpuinfo | grep -i vfp | tr ' ' '\n' | grep -i vfp | tail -1 ; })
 
 YACC = bison
 YACC_FLAGS = -y -d -t -v


### PR DESCRIPTION
Even though it might be an edge case, flathead wouldn't compile on my android phone due to VFP errors with gcc.

This will fix it but it might be time for a configure script. 